### PR TITLE
Fix warning: toplevel constant JSON referenced by Watir::Object::JSON

### DIFF
--- a/lib/watir-performance.rb
+++ b/lib/watir-performance.rb
@@ -88,7 +88,7 @@ module Watir
     def performance
       data = case driver.browser
       when :internet_explorer
-        Object::JSON.parse(driver.execute_script("return JSON.stringify(window.performance.toJSON());"))
+        ::Object::JSON.parse(driver.execute_script("return JSON.stringify(window.performance.toJSON());"))
       else
         driver.execute_script("return window.performance || window.webkitPerformance || window.mozPerformance || window.msPerformance;")
       end

--- a/watir-performance.gemspec
+++ b/watir-performance.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = "watir-performance"
-  s.version = "0.3.1"
+  s.version = "0.3.2"
   s.required_ruby_version = ['>= 2.2.0', '<= 2.4.3']
   s.authors = ["Tim Koopmans", "Robert MacCracken"]
   s.date = "2016-12-27"


### PR DESCRIPTION
Invoking `Browser#performance` prints `warning: toplevel constant JSON referenced by Watir::Object::JSON` to log. This PR fixes the warning.